### PR TITLE
Bugfixes for Modules/FindESMF.cmake and Modules/FindNetCDF.cmake

### DIFF
--- a/Modules/FindESMF.cmake
+++ b/Modules/FindESMF.cmake
@@ -71,14 +71,15 @@ if (ESMF_FOUND)
       endif()
     endif()
   endforeach()
+
+  string(REPLACE "-I" "" ESMF_F90COMPILEPATHS ${ESMF_F90COMPILEPATHS})
+  string(REPLACE " " ";" ESMF_F90COMPILEPATHS ${ESMF_F90COMPILEPATHS})
+
+  add_library(esmf SHARED IMPORTED)
+  find_library(esmf_lib NAMES esmf_fullylinked PATHS ${ESMF_LIBSDIR})
+
+  set_target_properties(esmf PROPERTIES
+    IMPORTED_LOCATION ${esmf_lib}
+    INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}")
+
 endif()
-
-string(REPLACE "-I" "" ESMF_F90COMPILEPATHS ${ESMF_F90COMPILEPATHS})
-string(REPLACE " " ";" ESMF_F90COMPILEPATHS ${ESMF_F90COMPILEPATHS})
-
-add_library(esmf SHARED IMPORTED)
-find_library(esmf_lib NAMES esmf_fullylinked PATHS ${ESMF_LIBSDIR})
-
-set_target_properties(esmf PROPERTIES
-  IMPORTED_LOCATION ${esmf_lib}
-  INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}")


### PR DESCRIPTION
Bugfixes for Modules/FindESMF.cmake and Modules/FindNetCDF.cmake to work with or without existing installations of netCDF and ESMF.

The netCDF changes were already in ufs_release_v1.0 but didn't make it into Mark's version it seems.

I tested this using -DBUILD_MISSING=ON for two different scenarios, one where everthing except Jasper was already installed, and one where only zlib and libpng where available (from the OS).